### PR TITLE
Update ultralytics doc link text

### DIFF
--- a/mcp_doc.txt
+++ b/mcp_doc.txt
@@ -2,6 +2,6 @@ adapter doc
 
 https://chatgpt.com/s/dr_682f0708e850819185b632ba2fb4f569
 
-ultrlytics doc
+ultralytics doc
 
 https://chatgpt.com/s/dr_682f948cd2488191a7d29ee7662a19a2


### PR DESCRIPTION
## Summary
- fix spelling in `mcp_doc.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840af6281b0832f9615c372a934f0e9