### PR TITLE
Add generic yolo_cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repo demonstrates a reference implementation using Ultralytics YOLOv8 (with
 - **Comprehensive Testing:** End-to-end tests with pytest, sample images, and automation.
 - **Video & Image Support:** Analyze videos by time range or frame, as well as images.
 - **Model Hot-Swap:** Swap model files on a running service without downtime.
+- **Ultralytics CLI Access:** Train or run any command via the new `yolo_cli` tool.
 - **Extensible API:** Easily add new endpoints and capabilities.
 
 ---
@@ -99,6 +100,11 @@ curl -F file=@test.jpg http://localhost:8080/detect
 #### Test Adapter (proxies to YOLO)
 ```powershell
 Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"detect_objects","input":{"image_path":"test.jpg"}}'
+```
+
+#### Run Any Ultralytics CLI Command
+```powershell
+Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"yolo_cli","input":{"args":"train model=yolov8n.pt data=coco128.yaml epochs=1"}}'
 ```
 
 ---

--- a/README.tr.md
+++ b/README.tr.md
@@ -22,6 +22,7 @@
 - **Test Kapsamı:** Pytest ile uçtan uca testler, örnek test görselleri ve otomasyon.
 - **Video & Görüntü Desteği:** Video dosyalarında zaman dilimi veya kare bazlı analiz.
 - **Model Hot-Swap:** Çalışan serviste model dosyasını kolayca değiştir.
+- **Ultralytics CLI Erişimi:** Yeni `yolo_cli` aracı ile tüm komutları çalıştır.
 - **Kapsamlı API:** Kolayca genişletilebilir endpoint yapısı.
 
 ---
@@ -85,6 +86,11 @@ curl -F file=@test.jpg http://localhost:8080/detect
 #### Adapter'ı Test Et (YOLO'ya proxy)
 ```powershell
 Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"detect_objects","input":{"image_path":"test.jpg"}}'
+```
+
+#### Ultralytics CLI Komutu Çalıştır
+```powershell
+Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"yolo_cli","input":{"args":"train model=yolov8n.pt data=coco128.yaml epochs=1"}}'
 ```
 
 ---

--- a/mcp_vision_adapter.egg-info/PKG-INFO
+++ b/mcp_vision_adapter.egg-info/PKG-INFO
@@ -1,63 +1,175 @@
 Metadata-Version: 2.4
 Name: mcp_vision_adapter
-Version: 0.1.0
+Version: 0.3.0
 Summary: MCP Vision Adapter
 Author-email: Your Name <your@email.com>
 Requires-Python: >=3.8
 Description-Content-Type: text/markdown
+License-File: LICENSE
+Dynamic: license-file
+
+
+
 
 # MCP Vision Adapter
 
-A minimal MCP adapter for VS Code Copilot Agent Mode (REST + STDIO).
+<p align="center">
+  <img src="https://img.shields.io/badge/MCP%20Protocol-2024--03--26-blue" alt="MCP Protocol Version"/>
+  <img src="https://img.shields.io/badge/Universal%20CLI%20Adapter-hub%20for%20LLMs-orange" alt="Universal CLI Adapter"/>
+  <img src="https://img.shields.io/badge/REST%20%2B%20STDIO-API-green" alt="REST + STDIO API"/>
+  <img src="https://img.shields.io/badge/License-MIT-yellow" alt="MIT License"/>
+</p>
+
+<h3 align="center">MCP Service for Oldies but Goldies</h3>
+
+**MCP Vision Adapter** is a universal, open-source MCP (Model Context Protocol) adapter for all CLI projects. It is designed to modernize and connect your classic automations, scripts, and detection tools to LLM/agent ecosystems—no matter how old or gold they are!
+
+> "Turn your legacy CLI automations into LLM/agent tools. If your software has a CLI, you can make it an agent tool—no rewrite required."
+
+This repo demonstrates a reference implementation using Ultralytics YOLOv8 (with CLI support) as an example service. You can register your own custom YOLOv8 models or any CLI-based tool as an agent tool and get detection results, comments, or outputs directly in your LLM workflows.
+
+**MCP Protocol Version:** `2024-03-26`  
+**Standard:** [Model Context Protocol (MCP)](https://github.com/microsoft/model-context-protocol)
+
+---
+
+---
+
+## 🚀 Key Features
+
+- **Ultralytics YOLOv8 Integration:** Fast and accurate object detection, segmentation, and pose estimation.
+- **REST & STDIO API:** Easy integration via both HTTP/REST and stdio.
+- **Web UI for Model Management:** Built-in Streamlit interface to load, swap, manage models, and view live results.
+- **VS Code Copilot Agent Mode:** Native integration with VS Code, automated tests, and code assistant support.
+- **Easy Docker & Compose Setup:** Spin up all services with a single command.
+- **Fully Open Source & MIT Licensed:** Free for commercial and personal use, easy to extend.
+- **Comprehensive Testing:** End-to-end tests with pytest, sample images, and automation.
+- **Video & Image Support:** Analyze videos by time range or frame, as well as images.
+- **Model Hot-Swap:** Swap model files on a running service without downtime.
+- **Extensible API:** Easily add new endpoints and capabilities.
+
+---
 
 
-## Quick Start
+## 🚦 Quick Start
 
-### Docker Compose (YOLOv8 + Adapter)
+You can run the MCP Adapter and YOLOv8 service in three ways:
+
+### 1. Virtual Environment (Recommended for Dev)
+
+**Step 1:** Create and activate a virtual environment (venv or conda)
+```powershell
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+# or with conda
+conda create -n mcp python=3.10
+conda activate mcp
+```
+**Step 2:** Install dependencies
+```powershell
+pip install -r yolov8_service/requirements.txt
+pip install -e .
+```
+**Step 3:** Start YOLOv8 service
+```powershell
+cd yolov8_service
+uvicorn app.main:app --host 0.0.0.0 --port 8080
+# (Optional) Streamlit UI: streamlit run app/streamlit_app.py --server.port 8501 --server.address 0.0.0.0
+```
+**Step 4:** Start MCP Adapter
+```powershell
+cd ..
+uvicorn mcp_vision_adapter.main:app --port 3000
+```
+
+### 2. Docker Based (YOLOv8 + Adapter)
+
+**Step 1:** Build and run both services with Docker Compose
+```powershell
+docker-compose up --build
+```
+- YOLOv8 service: [http://localhost:8080](http://localhost:8080)
+- Adapter: [http://localhost:3000](http://localhost:3000)
+- Streamlit UI: [http://localhost:8501](http://localhost:8501)
+
+### 3. All-in-One: Just Docker Compose!
+
+The provided `docker-compose.yml` launches both YOLOv8 and MCP Adapter, with all ports mapped and model management UI enabled. Just run:
 ```powershell
 docker-compose up --build
 ```
 
-- YOLOv8 service: [http://localhost:8080](http://localhost:8080)
-- Adapter: [http://localhost:3000](http://localhost:3000)
+---
 
-#### Test YOLOv8 service
+#### Test YOLOv8 Service
 ```powershell
 curl -F file=@test.jpg http://localhost:8080/detect
 ```
 
 #### Test Adapter (proxies to YOLO)
 ```powershell
-curl -X POST http://localhost:3000/execute -H "Content-Type: application/json" -d '{"tool":"detect_objects","input":{"image_path":"test.jpg"}}'
+Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"detect_objects","input":{"image_path":"test.jpg"}}'
 ```
 
-### STDIO mode
+---
+
+### STDIO Mode (Currently not supported for VS Code Copilot tool execution)
 ```
 python -m mcp_vision_adapter.main
 ```
+> ⚠️ **Note:** VS Code Copilot tool execution via STDIO is currently not supported. Please use the HTTP API for full integration. This will be fixed in an upcoming update.
+## 🤝 Contributing
 
-### HTTP/SSE mode
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. The goal is to make this repo a hub for connecting classic automations and tools to modern LLM/agent environments. Contact [Metehan Yaşar on LinkedIn](https://www.linkedin.com/in/metehan-y-16475a164/) for questions or collaboration.
+
+---
+
+## 🛣️ Roadmap & Future Updates
+
+- **Hotfix:** VS Code Copilot tool execution via STDIO is currently not supported. Use HTTP API for now. This will be fixed soon.
+- **Upcoming:**
+  - **n8n Example Automation:** A ready-to-use n8n template and a short usage video will be added.
+  - **Complete Ultralytics Service:** Full support for pose and segmentation tasks, including time-sliced video analysis, coming within 2 weeks. This repo is a reference CLI-to-MCP service.
+  - **v2: Automation Agent:** An OpenAI model will be integrated, enabling agent-based automation as a service. This will allow connecting automations as services—stay tuned!
+
+---
+
+## 🛠️ Custom Service Integration Tutorial
+
+To connect your own service or tool as an adapter:
+
+1. Implement a REST or STDIO interface that matches the MCP protocol (see `mcp_vision_adapter/main.py`).
+2. Register your service in `.vscode/mcp.json` or your orchestrator.
+3. Use the HTTP API for best compatibility:
+   ```powershell
+   Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"your_tool","input":{...}}'
+   ```
+4. For advanced use, see the test suite and example adapters.
+
+---
+
+### HTTP/SSE Mode
 ```
 uvicorn mcp_vision_adapter.main:app --port 3000
 ```
 
 ---
 
-## YOLOv8 Microservice
+## 🦾 YOLOv8 Microservice
 
-See [`yolov8_service/README.md`](yolov8_service/README.md) for endpoints, Docker usage, and time slicing params.
+See [`yolov8_service/README.md`](yolov8_service/README.md) for advanced usage and details.
 
-**Mount your models:**
+**Mount your model folder:**
 ```powershell
 docker run -v ${PWD}/models:/weights ...
 ```
-Default weights: `/weights/yolov8n.pt`
+Default weights file: `/weights/yolov8n.pt`
 
 ---
 
-## VS Code MCP Integration
+## 🧩 VS Code MCP Integration
 
-Sample `.vscode/mcp.json`:
+Example `.vscode/mcp.json`:
 ```jsonc
 {
   "servers": {
@@ -76,7 +188,7 @@ Sample `.vscode/mcp.json`:
 
 ---
 
-## Testing
+## 🧪 Testing
 
 ```powershell
 pip install fastapi uvicorn pytest
@@ -86,17 +198,37 @@ pytest -q
 Tests:
 - `test_service_detect.py`: YOLOv8 service (direct)
 - `test_adapter_proxy.py`: Adapter → YOLOv8 service
-- All existing adapter tests remain green
+- `test_stdio_exec.py`, `test_exec_env.py`: STDIO and env tests
+- All tests are automated and end-to-end
 
 ---
 
-## Notes
+## 📝 Notes
 
-- For video, use `start`/`end` (e.g. `?start=2s&end=5s`) or `frame` for slicing.
-- If neither `manual_result` nor `MANUAL_RESULT` env is set and the adapter is not running in a TTY, it returns a placeholder string.
+- For video, use `start`/`end` (e.g. `?start=2s&end=5s`) or `frame` params.
+- If neither `manual_result` nor `MANUAL_RESULT` is set and the adapter is not running in a TTY, a placeholder is returned.
 
 ---
 
-### Port Clash
+### ⚠️ Port Clash
 
 If Uvicorn port 3000 is busy, stop the previous process (CTRL-C) or run with `--port 3001` and update `mcp.json` accordingly.
+
+---
+
+## 🌍 Open Source & License
+
+This project is open source under the MIT license. Contributions are welcome!
+
+---
+
+## Security & Privacy
+
+- No secret keys, passwords, or access tokens are included in the codebase.
+- Example values like `GITHUB_PERSONAL_ACCESS_TOKEN` are for documentation and test purposes only. Always use your own keys securely.
+
+---
+
+## 🇹🇷 Türkçe Dokümantasyon
+
+Bu projenin Türkçe dokümantasyonu da mevcuttur. [README.tr.md](README.tr.md) dosyasına göz atabilirsiniz.

--- a/mcp_vision_adapter.egg-info/SOURCES.txt
+++ b/mcp_vision_adapter.egg-info/SOURCES.txt
@@ -1,3 +1,4 @@
+LICENSE
 README.md
 pyproject.toml
 setup.cfg

--- a/mcp_vision_adapter/__init__.py
+++ b/mcp_vision_adapter/__init__.py
@@ -1,3 +1,2 @@
-
 # mcp_vision_adapter package
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/mcp_vision_adapter/main.py
+++ b/mcp_vision_adapter/main.py
@@ -1,26 +1,10 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 import os
 import sys
 import json
 import logging
+import subprocess
+import shlex
 from typing import Any, Dict
-
 
 
 from fastapi import FastAPI, Request
@@ -35,8 +19,8 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
     handlers=[
         logging.FileHandler(LOG_FILE, encoding="utf-8"),
-        logging.StreamHandler(sys.stderr)
-    ]
+        logging.StreamHandler(sys.stderr),
+    ],
 )
 
 app = FastAPI()
@@ -50,53 +34,117 @@ MANIFEST = {
                 "type": "object",
                 "properties": {
                     "image_path": {"type": "string"},
-                    "manual_result": {"type": "string", "description": "Optional manual result override."}
+                    "manual_result": {
+                        "type": "string",
+                        "description": "Optional manual result override.",
+                    },
                 },
-                "required": ["image_path"]
-            }
-        }
+                "required": ["image_path"],
+            },
+        },
+        {
+            "name": "yolo_cli",
+            "description": "Run any Ultralytics CLI command (e.g. train, predict).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "args": {
+                        "type": "string",
+                        "description": "Arguments passed to `python -m ultralytics`, such as 'train model=yolov8n.pt data=coco128.yaml'",
+                    }
+                },
+                "required": ["args"],
+            },
+        },
     ]
 }
 
 PROTOCOL_VERSION = "2024-03-26"
 
+
 # --- STDIO/REST shared logic ---
 def get_manifest() -> Dict[str, Any]:
     return {"tools": MANIFEST["tools"]}
+
 
 def get_initialize_response() -> Dict[str, Any]:
     return {
         "result": {
             "protocolVersion": PROTOCOL_VERSION,
-            "capabilities": {
-                "tools": {
-                    "listChanged": True
-                }
-            }
+            "capabilities": {"tools": {"listChanged": True}},
         }
     }
 
+
 def read_manual_line(prompt: str) -> str:
     import sys, os
+
     sys.stderr.write(prompt)
     sys.stderr.flush()
     try:
         if os.name == "nt":
             import msvcrt
+
             chars = []
             while True:
                 ch = msvcrt.getwch()
-                if ch in ('\r', '\n'):
+                if ch in ("\r", "\n"):
                     break
                 chars.append(ch)
-            return ''.join(chars)
+            return "".join(chars)
         else:
             return sys.__stdin__.readline().rstrip("\n")
     except Exception:
         return input()
 
-def detect_objects_impl(image_path: str, root: str = None, manual_result: str = None) -> str:
-    logging.info(f"[detect_objects_impl] Called with image_path={image_path}, root={root}, manual_result={manual_result}")
+
+def _post_file(url: str, file_obj) -> Any:
+    """Minimal HTTP multipart POST using stdlib."""
+    import uuid
+    import http.client
+    import urllib.parse
+
+    boundary = "----MCP" + uuid.uuid4().hex
+    filename = os.path.basename(file_obj.name)
+    content = file_obj.read()
+    body = (
+        (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+            f"Content-Type: application/octet-stream\r\n\r\n"
+        ).encode()
+        + content
+        + f"\r\n--{boundary}--\r\n".encode()
+    )
+
+    parsed = urllib.parse.urlsplit(url)
+    path = parsed.path or "/"
+    if parsed.query:
+        path += "?" + parsed.query
+    conn = http.client.HTTPConnection(parsed.hostname, parsed.port or 80, timeout=60)
+    conn.request(
+        "POST",
+        path,
+        body,
+        {"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    if 200 <= resp.status < 300:
+        try:
+            return json.loads(data)
+        except Exception:
+            return {}
+    raise RuntimeError(f"HTTP {resp.status}: {data.decode()}")
+
+
+def detect_objects_impl(
+    image_path: str, root: str = None, manual_result: str = None
+) -> str:
+    logging.info(
+        f"[detect_objects_impl] Called with image_path={image_path}, root={root}, manual_result={manual_result}"
+    )
     # Manual overrides are currently disabled. The commented code below is
     # legacy behavior kept for reference only.
     # if manual_result:
@@ -114,18 +162,35 @@ def detect_objects_impl(image_path: str, root: str = None, manual_result: str = 
         return f"[error: file not found: {image_path}]"
 
     # --- YOLOv8 service integration ---
-    import requests
+    try:
+        import requests  # type: ignore
+    except Exception:  # requests may not be installed
+        requests = None
+
     YOLO_SERVICE = os.getenv("YOLO_SERVICE_URL", "http://localhost:8080")
-    logging.info(f"[detect_objects_impl] Sending to YOLO_SERVICE: {YOLO_SERVICE}/detect")
+    logging.info(
+        f"[detect_objects_impl] Sending to YOLO_SERVICE: {YOLO_SERVICE}/detect"
+    )
     try:
         with open(image_path, "rb") as f:
-            files = {"file": (os.path.basename(image_path), f, "application/octet-stream")}
-            resp = requests.post(f"{YOLO_SERVICE}/detect", files=files, timeout=60)
-        resp.raise_for_status()
-        data = resp.json()
+            if requests:
+                files = {
+                    "file": (
+                        os.path.basename(image_path),
+                        f,
+                        "application/octet-stream",
+                    )
+                }
+                resp = requests.post(f"{YOLO_SERVICE}/detect", files=files, timeout=60)
+                resp.raise_for_status()
+                data = resp.json()
+            else:
+                data = _post_file(f"{YOLO_SERVICE}/detect", f)
         logging.info(f"[detect_objects_impl] YOLO response: {data}")
         # Return summary text: class list
-        classes = [r.get("class_", r.get("class", "?")) for r in data.get("results", [])]
+        classes = [
+            r.get("class_", r.get("class", "?")) for r in data.get("results", [])
+        ]
         if not classes:
             logging.info("[detect_objects_impl] No objects detected.")
             return "No objects detected."
@@ -139,13 +204,32 @@ def detect_objects_impl(image_path: str, root: str = None, manual_result: str = 
     return "[error: object detection failed]"
 
 
+def run_yolo_cli(args: str, root: str = None) -> str:
+    """Run an arbitrary Ultralytics CLI command."""
+    logging.info(f"[run_yolo_cli] args={args}, root={root}")
+    cmd = [sys.executable, "-m", "ultralytics"] + shlex.split(args)
+    logging.info(f"[run_yolo_cli] Running command: {' '.join(cmd)}")
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=root)
+        if proc.returncode != 0:
+            logging.error(f"[run_yolo_cli] Error: {proc.stderr}")
+            return proc.stderr.strip()
+        return proc.stdout.strip() or "done"
+    except Exception as e:
+        logging.error(f"[run_yolo_cli] Exception: {e}", exc_info=True)
+        return f"[error: {e}]"
+
+
 def execute_tool(tool_name: str, params: Dict[str, Any], root: str = None) -> Any:
     logging.info(f"[execute_tool] tool_name={tool_name}, params={params}, root={root}")
     if tool_name == "detect_objects":
         manual_result = params.get("manual_result")
         return detect_objects_impl(params["image_path"], root, manual_result)
+    if tool_name == "yolo_cli":
+        return run_yolo_cli(params.get("args", ""), root)
     logging.error(f"[execute_tool] Unknown tool: {tool_name}")
     raise Exception(f"Unknown tool: {tool_name}")
+
 
 # --- JSON-RPC universal dispatcher for POST / ---
 def handle_call(payload, root=None):
@@ -155,7 +239,6 @@ def handle_call(payload, root=None):
     result = execute_tool(tool, params, root)
     logging.info(f"[handle_call] result={result}")
     return {"result": result}
-
 
 
 @app.post("/")
@@ -177,19 +260,30 @@ async def root_rpc(request: Request):
                 call_result = handle_call(params)
                 return {"jsonrpc": "2.0", "id": jsonrpc_id, **call_result}
             except Exception as e:
-                return {"jsonrpc": "2.0", "id": jsonrpc_id, "error": {"code": -32000, "message": str(e)}}
+                return {
+                    "jsonrpc": "2.0",
+                    "id": jsonrpc_id,
+                    "error": {"code": -32000, "message": str(e)},
+                }
         else:
-            return {"jsonrpc": "2.0", "id": jsonrpc_id, "error": {"code": -32601, "message": f"Unknown method: {method}"}}
+            return {
+                "jsonrpc": "2.0",
+                "id": jsonrpc_id,
+                "error": {"code": -32601, "message": f"Unknown method: {method}"},
+            }
     except Exception as e:
         return {"jsonrpc": "2.0", "error": {"code": -32603, "message": str(e)}}
+
 
 @app.post("/initialize")
 async def http_initialize():
     return get_initialize_response()
 
+
 @app.get("/manifest")
 async def http_manifest():
     return get_manifest()
+
 
 @app.post("/execute")
 async def http_execute(request: Request):
@@ -202,10 +296,12 @@ async def http_execute(request: Request):
     except Exception as e:
         return JSONResponse(status_code=400, content={"error": str(e)})
 
+
 @app.api_route("/tools/list", methods=["POST"])
 @app.api_route("/tools/list/", methods=["POST"])
 async def http_tools_list():
     return get_manifest()
+
 
 @app.post("/tools/call")
 async def http_tools_call(request: Request):
@@ -218,15 +314,18 @@ async def http_tools_call(request: Request):
     except Exception as e:
         return JSONResponse(status_code=400, content={"error": str(e)})
 
+
 @app.get("/sse")
 async def http_sse():
     async def event_stream():
         yield "event: listChanged\ndata: {}\n\n"
+
     return StreamingResponse(event_stream(), media_type="text/event-stream")
+
 
 @app.get("/ui")
 async def http_ui():
-    html = '''
+    html = """
     <!DOCTYPE html>
     <html lang="en">
     <head><meta charset="utf-8"><title>MCP Vision Adapter UI</title></head>
@@ -251,7 +350,7 @@ async def http_ui():
     }
     </script>
     </body></html>
-    '''
+    """
     return JSONResponse(content=html, media_type="text/html")
 
 
@@ -285,21 +384,36 @@ def stdio_main():
                 tool = req["params"]["tool"]
                 params = req["params"]["input"]
                 try:
-                    logging.info(f"[stdio_main] Calling tool: {tool} with params: {params} and root: {root}")
+                    logging.info(
+                        f"[stdio_main] Calling tool: {tool} with params: {params} and root: {root}"
+                    )
                     result = execute_tool(tool, params, root)
                     resp = {"jsonrpc": "2.0", "id": req_id, "result": result}
                     logging.info(f"[stdio_main] Tool result: {result}")
                 except Exception as e:
-                    logging.error(f"[stdio_main] Tool execution error: {e}", exc_info=True)
-                    resp = {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32000, "message": str(e)}}
+                    logging.error(
+                        f"[stdio_main] Tool execution error: {e}", exc_info=True
+                    )
+                    resp = {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "error": {"code": -32000, "message": str(e)},
+                    }
             else:
                 logging.error(f"[stdio_main] Unknown method: {method}")
-                resp = {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": "Unknown method"}}
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32601, "message": "Unknown method"},
+                }
         except Exception as e:
             logging.error(f"[stdio_main] Exception: {e}", exc_info=True)
-            resp = {"jsonrpc": "2.0", "id": None, "error": {"code": -32603, "message": str(e)}}
+            resp = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32603, "message": str(e)},
+            }
         print(json.dumps(resp), flush=True)
-
 
 
 # Only run stdio_main if this file is executed as a script, not on import (e.g. by pytest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp_vision_adapter"
-version = "0.1.0"
+version = "0.3.0"
 description = "MCP Vision Adapter"
 authors = [
     { name = "Your Name", email = "your@email.com" }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcp_vision_adapter
-version = 0.1.0
+version = 0.3.0
 
 [options]
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mcp_vision_adapter",
-    version="0.1.0",
+    version="0.3.0",
     packages=["mcp_vision_adapter"],
     install_requires=[],
 )


### PR DESCRIPTION
## Summary
- allow arbitrary Ultralytics commands via the new `yolo_cli` tool
- implement `_post_file` to avoid the requests dependency
- document training example and CLI access in both READMEs
- bump package version to 0.3.0

## Testing
- `black mcp_vision_adapter/main.py mcp_vision_adapter/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6863ddb7e3bc832f825bf84b17c519cf