### PR TITLE
Add docs for yolo_cli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This repo demonstrates a reference implementation using Ultralytics YOLOv8 (with
 - **Video & Image Support:** Analyze videos by time range or frame, as well as images.
 - **Model Hot-Swap:** Swap model files on a running service without downtime.
 - **Extensible API:** Easily add new endpoints and capabilities.
+- **Ultralytics CLI Support:** Execute any `ultralytics` command through the `yolo_cli` tool.
 
 ---
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -23,6 +23,7 @@
 - **Video & Görüntü Desteği:** Video dosyalarında zaman dilimi veya kare bazlı analiz.
 - **Model Hot-Swap:** Çalışan serviste model dosyasını kolayca değiştir.
 - **Kapsamlı API:** Kolayca genişletilebilir endpoint yapısı.
+- **Ultralytics CLI Desteği:** `yolo_cli` aracı ile tüm `ultralytics` komutlarını çalıştır.
 
 ---
 
@@ -85,6 +86,11 @@ curl -F file=@test.jpg http://localhost:8080/detect
 #### Adapter'ı Test Et (YOLO'ya proxy)
 ```powershell
 Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"detect_objects","input":{"image_path":"test.jpg"}}'
+```
+
+#### Herhangi Bir Ultralytics CLI Komutunu Çalıştır
+```powershell
+Invoke-RestMethod -Uri "http://localhost:3000/execute" -Method Post -ContentType "application/json" -Body '{"tool":"yolo_cli","input":{"args":"train model=yolov8n.pt data=coco128.yaml epochs=1"}}'
 ```
 
 ---

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -14,6 +14,7 @@ def test_manifest_lists_detect_objects():
     tools = manifest["tools"]
     tool_names = [t["name"] for t in tools]
     assert "detect_objects" in tool_names
+    assert "yolo_cli" in tool_names
     # Check inputSchema key exists for detect_objects
     detect_tool = next(t for t in tools if t["name"] == "detect_objects")
     assert "inputSchema" in detect_tool
@@ -29,5 +30,6 @@ def test_tools_list_http():
             data = resp.json()
             assert "tools" in data
             assert any(t["name"] == "detect_objects" for t in data["tools"])
+            assert any(t["name"] == "yolo_cli" for t in data["tools"])
             return
     pytest.fail("Neither /tools/list nor /tools/list/ returned 200")

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -23,3 +23,4 @@ def test_manifest_includes_detect_objects():
     data = resp.json()
     assert "tools" in data
     assert any(t.get("name") == "detect_objects" for t in data["tools"])
+    assert any(t.get("name") == "yolo_cli" for t in data["tools"])


### PR DESCRIPTION
## Summary
- document `yolo_cli` feature in both READMEs
- add CLI example to Turkish docs
- verify manifest includes `yolo_cli` in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863ea8797fc832f9046be4d03375c44